### PR TITLE
Corrected answers for Python dictionary questions

### DIFF
--- a/Dictionaries TEST.md
+++ b/Dictionaries TEST.md
@@ -111,7 +111,7 @@ print(my_dict)
 <details><summary><b>Answer</b></summary>
 <p>
 
-#### Correct Answer -> A blueprint for creating objects
+#### Correct Answer -> D: By directly assigning a value to a new key
 
 </p>
 </details>
@@ -126,7 +126,7 @@ print(my_dict)
 <details><summary><b>Answer</b></summary>
 <p>
 
-#### Correct Answer -> D: Using a while loop with iteritems()
+#### Correct Answer -> C: Using a for loop with items()
 
 </p>
 </details>


### PR DESCRIPTION
**Question 7** -> the correct answer "Using the append() method" is incorrect because dictionaries in Python do not have an append() method. However, in Python, we can add a new key-value pair to an existing dictionary by directly assigning a value to a new key
**Question 8** - > the correct answer "Using a while loop with iteritems()" is incorrect. However, in Python 3, this method was removed, and instead, the items() method was introduced, the correct way to iterate over all key-value pairs in a dictionary is to use a for loop with the items() method, not a while loop with iteritems().